### PR TITLE
Add FirePass provider support for Kimi K2.5 Turbo

### DIFF
--- a/src/commands/login/login.tsx
+++ b/src/commands/login/login.tsx
@@ -11,6 +11,7 @@ import { ConfigurableShortcutHint } from '../../components/ConfigurableShortcutH
 import { ConsoleOAuthFlow } from '../../components/ConsoleOAuthFlow.js'
 import { Select } from '../../components/CustomSelect/select.js'
 import { Dialog } from '../../components/design-system/Dialog.js'
+import { FirepassLoginFlow } from '../../components/FirepassLoginFlow.js'
 import { OpenAILoginFlow } from '../../components/OpenAILoginFlow.js'
 import { OpenRouterLoginFlow } from '../../components/OpenRouterLoginFlow.js'
 import { useMainLoopModel } from '../../hooks/useMainLoopModel.js'
@@ -29,7 +30,7 @@ import {
 } from '../../utils/permissions/bypassPermissionsKillswitch.js'
 import { resetUserCache } from '../../utils/user.js'
 
-type AuthProviderChoice = 'anthropic' | 'openai' | 'openrouter'
+type AuthProviderChoice = 'anthropic' | 'openai' | 'openrouter' | 'firepass'
 
 export async function call(
   onDone: LocalJSXCommandOnDone,
@@ -124,6 +125,18 @@ export function Login(props: {
         ),
         value: 'openrouter',
       },
+      {
+        label: (
+          <Text>
+            FirePass{' '}
+            <Text dimColor={true}>
+              Fireworks API key with Kimi K2.5 Turbo subscription
+            </Text>
+            {'\n'}
+          </Text>
+        ),
+        value: 'firepass',
+      },
     ],
     [],
   )
@@ -161,6 +174,11 @@ export function Login(props: {
       <OpenRouterLoginFlow
         onDone={onFlowDone}
         startingMessage="Better-Clawd can use OpenRouter with your OpenRouter API key."
+      />
+    ) : selectedProvider === 'firepass' ? (
+      <FirepassLoginFlow
+        onDone={onFlowDone}
+        startingMessage="Better-Clawd can use FirePass with your Fireworks API key for Kimi K2.5 Turbo."
       />
     ) : (
       <ConsoleOAuthFlow

--- a/src/components/FirepassLoginFlow.tsx
+++ b/src/components/FirepassLoginFlow.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { Box, Text } from '../ink.js'
+import { saveFirepassApiKey } from '../utils/auth.js'
+import { Spinner } from './Spinner.js'
+import TextInput from './TextInput.js'
+
+type FirepassLoginFlowProps = {
+  onDone: () => void
+  startingMessage?: string
+}
+
+export function FirepassLoginFlow({
+  onDone,
+  startingMessage,
+}: FirepassLoginFlowProps): React.ReactNode {
+  const [isBusy, setIsBusy] = useState(false)
+  const [status, setStatus] = useState<string | null>(null)
+  const [inputValue, setInputValue] = useState('')
+  const [cursorOffset, setCursorOffset] = useState(0)
+
+  async function handleSubmit(value: string): Promise<void> {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return
+    }
+
+    setIsBusy(true)
+    setStatus(null)
+    try {
+      await saveFirepassApiKey(trimmed)
+      onDone()
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error))
+    } finally {
+      setIsBusy(false)
+    }
+  }
+
+  if (isBusy) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Box>
+          <Spinner />
+          <Text>Configuring FirePass login for Better-Clawd...</Text>
+        </Box>
+        <Text dimColor={true}>
+          FirePass uses your Fireworks API key with the Anthropic-compatible
+          endpoint at `https://api.fireworks.ai/inference`.
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text>
+        {startingMessage ??
+          'Better-Clawd can use FirePass with your Fireworks API key.'}
+      </Text>
+      <Text dimColor={true}>
+        FirePass provides subscription-based access to Kimi K2.5 Turbo with no
+        per-token charges. Get FirePass at{' '}
+        <Text color="cyan">https://app.fireworks.ai/fire-pass</Text>
+      </Text>
+      <Box>
+        <Text>Paste your Fireworks API key:</Text>
+        <TextInput
+          value={inputValue}
+          onChange={setInputValue}
+          onSubmit={handleSubmit}
+          onExit={() => {
+            setInputValue('')
+            setCursorOffset(0)
+          }}
+          cursorOffset={cursorOffset}
+          onChangeCursorOffset={setCursorOffset}
+          columns={72}
+          mask="*"
+        />
+      </Box>
+      {status ? <Text color="error">{status}</Text> : null}
+      <Text dimColor={true}>
+        Press <Text bold={true}>Enter</Text> to save, or <Text bold={true}>Esc</Text>{' '}
+        to cancel.
+      </Text>
+    </Box>
+  )
+}

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -6,6 +6,7 @@ import {
   getAnthropicApiKey,
   getApiKeyFromApiKeyHelper,
   getClaudeAIOAuthTokens,
+  getFirepassApiKey,
   getOpenAIApiKey,
   getOpenRouterApiKey,
   isClaudeAISubscriber,
@@ -17,6 +18,7 @@ import { getUserAgent } from 'src/utils/http.js'
 import { getSmallFastModel } from 'src/utils/model/model.js'
 import {
   getAPIProvider,
+  getFirepassBaseUrl,
   getOpenAIBaseUrl,
   getOpenRouterBaseUrl,
   isFirstPartyAnthropicBaseUrl,
@@ -309,6 +311,26 @@ export async function getAnthropicClient({
       apiKey: null,
       authToken: apiKey || getOpenRouterApiKey(),
       baseURL: getOpenRouterBaseUrl(),
+      ...ARGS,
+      ...(isDebugToStdErr() && { logger: createStderrLogger() }),
+    }
+
+    return new Anthropic(clientConfig)
+  }
+
+  if (provider === 'firepass') {
+    // FirePass uses Fireworks AI's Anthropic-compatible endpoint
+    // Requires an active FirePass subscription for the kimi-k2p5-turbo router
+    const firepassKey = apiKey || getFirepassApiKey()
+    if (!firepassKey) {
+      throw new Error(
+        'FirePass provider selected but no FirePass/Fireworks API key is configured. Set FIREPASS_API_KEY or FIREWORKS_API_KEY.',
+      )
+    }
+
+    const clientConfig: ConstructorParameters<typeof Anthropic>[0] = {
+      apiKey: firepassKey,
+      baseURL: getFirepassBaseUrl(),
       ...ARGS,
       ...(isDebugToStdErr() && { logger: createStderrLogger() }),
     }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -239,6 +239,12 @@ export type OpenRouterApiKeySource =
   | '/login managed OpenRouter key'
   | 'none'
 
+export type FirepassApiKeySource =
+  | 'FIREPASS_API_KEY'
+  | 'FIREWORKS_API_KEY'
+  | '/login managed FirePass key'
+  | 'none'
+
 export function getAnthropicApiKey(): null | string {
   const { key } = getAnthropicApiKeyWithSource()
   return key
@@ -307,10 +313,33 @@ export function getOpenRouterApiKeyWithSource(): {
     : { key: null, source: 'none' }
 }
 
+export function getFirepassApiKey(): null | string {
+  return getFirepassApiKeyWithSource().key
+}
+
+export function getFirepassApiKeyWithSource(): {
+  key: null | string
+  source: FirepassApiKeySource
+} {
+  // Check FIREPASS_API_KEY first, then fall back to FIREWORKS_API_KEY
+  if (process.env.FIREPASS_API_KEY) {
+    return { key: process.env.FIREPASS_API_KEY, source: 'FIREPASS_API_KEY' }
+  }
+  if (process.env.FIREWORKS_API_KEY) {
+    return { key: process.env.FIREWORKS_API_KEY, source: 'FIREWORKS_API_KEY' }
+  }
+
+  const key = getGlobalConfig().firepassApiKey
+  return key
+    ? { key, source: '/login managed FirePass key' }
+    : { key: null, source: 'none' }
+}
+
 export function getConfiguredAuthProvider():
   | 'anthropic'
   | 'openrouter'
-  | 'openai' {
+  | 'openai'
+  | 'firepass' {
   const storedProvider = getGlobalConfig().authProvider
   if (storedProvider) {
     return storedProvider
@@ -322,6 +351,8 @@ export function getConfiguredAuthProvider():
       return 'openrouter'
     case 'openai':
       return 'openai'
+    case 'firepass':
+      return 'firepass'
     default:
       return 'anthropic'
   }
@@ -1403,6 +1434,19 @@ export async function saveOpenRouterApiKey(apiKey: string): Promise<void> {
     ...current,
     authProvider: 'openrouter',
     openRouterApiKey: apiKey,
+  }))
+}
+
+export async function saveFirepassApiKey(apiKey: string): Promise<void> {
+  if (!isValidApiKey(apiKey)) {
+    throw new Error(
+      'Invalid API key format. API key must contain only alphanumeric characters, dashes, and underscores.',
+    )
+  }
+  saveGlobalConfig(current => ({
+    ...current,
+    authProvider: 'firepass',
+    firepassApiKey: apiKey,
   }))
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -221,7 +221,7 @@ export type GlobalConfig = {
     approved?: string[]
     rejected?: string[]
   }
-  authProvider?: 'anthropic' | 'openrouter' | 'openai'
+  authProvider?: 'anthropic' | 'openrouter' | 'openai' | 'firepass'
   primaryApiKey?: string // Primary API key for the user when no environment variable is set, set via oauth (TODO: rename)
   openAiApiKey?: string
   openAiAccessToken?: string
@@ -229,6 +229,7 @@ export type GlobalConfig = {
   openAiTokenExpiresAt?: number
   openAiWorkspaceId?: string
   openRouterApiKey?: string
+  firepassApiKey?: string
   hasAcknowledgedCostThreshold?: boolean
   hasSeenUndercoverAutoNotice?: boolean // ant-only: whether the one-time auto-undercover explainer has been shown
   hasSeenUltraplanTerms?: boolean // ant-only: whether the one-time CCR terms notice has been shown in the ultraplan launch dialog

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -11,6 +11,7 @@ import { OAUTH_BETA_HEADER } from '../constants/oauth.js'
 import {
   getAnthropicApiKey,
   getClaudeAIOAuthTokens,
+  getFirepassApiKey,
   getOpenAIApiKey,
   getOpenRouterApiKey,
   handleOAuth401Error,
@@ -96,6 +97,22 @@ export function getAuthHeaders(): AuthHeaders {
     return {
       headers: {
         Authorization: `Bearer ${apiKey}`,
+      },
+    }
+  }
+
+  if (provider === 'firepass') {
+    const apiKey = getFirepassApiKey()
+    if (!apiKey) {
+      return {
+        headers: {},
+        error: 'No FirePass API key available',
+      }
+    }
+    // FirePass uses x-api-key header like Anthropic
+    return {
+      headers: {
+        'x-api-key': apiKey,
       },
     }
   }

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -109,6 +109,10 @@ export function getDefaultOpusModel(): ModelName {
   if (process.env.ANTHROPIC_DEFAULT_OPUS_MODEL) {
     return process.env.ANTHROPIC_DEFAULT_OPUS_MODEL
   }
+  // FirePass uses Kimi K2.5 Turbo for all model tiers
+  if (getAPIProvider() === 'firepass') {
+    return getModelStrings().opus46
+  }
   // 3P providers (Bedrock, Vertex, Foundry) — kept as a separate branch
   // even when values match, since 3P availability lags firstParty and
   // these will diverge again at the next model launch.
@@ -123,6 +127,10 @@ export function getDefaultSonnetModel(): ModelName {
   if (process.env.ANTHROPIC_DEFAULT_SONNET_MODEL) {
     return process.env.ANTHROPIC_DEFAULT_SONNET_MODEL
   }
+  // FirePass uses Kimi K2.5 Turbo for all model tiers
+  if (getAPIProvider() === 'firepass') {
+    return getModelStrings().sonnet46
+  }
   // Default to Sonnet 4.5 for 3P since they may not have 4.6 yet
   if (getAPIProvider() !== 'firstParty') {
     return getModelStrings().sonnet45
@@ -135,7 +143,10 @@ export function getDefaultHaikuModel(): ModelName {
   if (process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL) {
     return process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL
   }
-
+  // FirePass uses Kimi K2.5 Turbo for all model tiers
+  if (getAPIProvider() === 'firepass') {
+    return getModelStrings().haiku45
+  }
   // Haiku 4.5 is available on all platforms (first-party, Foundry, Bedrock, Vertex)
   return getModelStrings().haiku45
 }
@@ -185,6 +196,11 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
       getAntModelOverrideConfig()?.defaultModel ??
       getDefaultOpusModel() + '[1m]'
     )
+  }
+
+  // FirePass uses Kimi K2.5 Turbo for all users
+  if (getAPIProvider() === 'firepass') {
+    return getModelStrings().sonnet46 // Returns Kimi K2.5 Turbo
   }
 
   // Max users get Opus as default
@@ -350,6 +366,10 @@ export function renderModelSetting(setting: ModelName | ModelAlias): string {
  * if the model is not recognized as a public model.
  */
 export function getPublicModelDisplayName(model: ModelName): string | null {
+  // FirePass Kimi K2.5 Turbo
+  if (model.includes('kimi-k2p5-turbo') || model.includes('kimi-k2.5-turbo')) {
+    return 'Kimi K2.5 Turbo'
+  }
   switch (model) {
     case getModelStrings().opus46:
       return 'Opus 4.6'
@@ -574,6 +594,11 @@ export function getMarketingNameForModel(modelId: string): string | undefined {
   if (getAPIProvider() === 'foundry') {
     // deployment ID is user-defined in Foundry, so it may have no relation to the actual model
     return undefined
+  }
+
+  // FirePass Kimi K2.5 Turbo
+  if (modelId.includes('kimi-k2p5-turbo') || modelId.includes('kimi-k2.5-turbo')) {
+    return 'Kimi K2.5 Turbo'
   }
 
   const has1m = modelId.toLowerCase().includes('[1m]')

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -45,6 +45,7 @@ export type ModelOption = {
 export function getDefaultOptionForUser(fastMode = false): ModelOption {
   const provider = getAPIProvider()
   const isOpenAI = provider === 'openai'
+  const isFirepass = provider === 'firepass'
   if (process.env.USER_TYPE === 'ant') {
     const currentModel = renderDefaultModelSetting(
       getDefaultMainLoopModelSetting(),
@@ -68,6 +69,14 @@ export function getDefaultOptionForUser(fastMode = false): ModelOption {
 
   // PAYG
   const is3P = provider !== 'firstParty'
+  if (isFirepass) {
+    return {
+      value: null,
+      label: 'Default (recommended)',
+      description: 'Use Kimi K2.5 Turbo (FirePass subscription)',
+      descriptionForModel: 'Kimi K2.5 Turbo - FirePass subscription with 256K context',
+    }
+  }
   return {
     value: null,
     label: 'Default (recommended)',
@@ -107,6 +116,16 @@ function getSonnet46Option(): ModelOption {
       description: 'GPT-5.4 · Recommended for most coding tasks',
       descriptionForModel:
         'GPT-5.4 - recommended for most coding and agentic tasks on OpenAI',
+    }
+  }
+  if (provider === 'firepass') {
+    const firepassModel = getModelStrings().sonnet46
+    return {
+      value: firepassModel,
+      label: 'Kimi K2.5 Turbo',
+      description: 'Kimi K2.5 Turbo · FirePass subscription model',
+      descriptionForModel:
+        'Kimi K2.5 Turbo - FirePass subscription with 256K context, no per-token charges',
     }
   }
   return {
@@ -156,6 +175,16 @@ function getOpus46Option(fastMode = false): ModelOption {
         'GPT-5.4 - most capable OpenAI model for complex coding work',
     }
   }
+  if (provider === 'firepass') {
+    const firepassModel = getModelStrings().opus46
+    return {
+      value: firepassModel,
+      label: 'Kimi K2.5 Turbo',
+      description: 'Kimi K2.5 Turbo · FirePass subscription model',
+      descriptionForModel:
+        'Kimi K2.5 Turbo - FirePass subscription with 256K context, no per-token charges',
+    }
+  }
   return {
     value: is3P ? getModelStrings().opus46 : 'opus',
     label: 'Opus',
@@ -174,6 +203,17 @@ export function getSonnet46_1MOption(): ModelOption {
       description: 'GPT-5.4 for long-running OpenAI sessions',
       descriptionForModel:
         'GPT-5.4 for long-running OpenAI sessions and large codebases',
+    }
+  }
+  if (provider === 'firepass') {
+    // FirePass Kimi has 256K context, no need for separate 1M option
+    const firepassModel = getModelStrings().sonnet46
+    return {
+      value: firepassModel,
+      label: 'Kimi K2.5 Turbo',
+      description: 'Kimi K2.5 Turbo · 256K context included',
+      descriptionForModel:
+        'Kimi K2.5 Turbo - 256K context window for long sessions',
     }
   }
   return {
@@ -195,6 +235,17 @@ export function getOpus46_1MOption(fastMode = false): ModelOption {
       description: 'GPT-5.4 for long-running OpenAI sessions',
       descriptionForModel:
         'GPT-5.4 for long-running OpenAI sessions and large codebases',
+    }
+  }
+  if (provider === 'firepass') {
+    // FirePass Kimi has 256K context, no need for separate 1M option
+    const firepassModel = getModelStrings().opus46
+    return {
+      value: firepassModel,
+      label: 'Kimi K2.5 Turbo',
+      description: 'Kimi K2.5 Turbo · 256K context included',
+      descriptionForModel:
+        'Kimi K2.5 Turbo - 256K context window for long sessions',
     }
   }
   return {
@@ -234,6 +285,16 @@ function getHaiku45Option(): ModelOption {
         'GPT-5.4 Mini - fastest OpenAI option for quick answers and lightweight tasks',
     }
   }
+  if (provider === 'firepass') {
+    const firepassModel = getModelStrings().haiku45
+    return {
+      value: firepassModel,
+      label: 'Kimi K2.5 Turbo',
+      description: 'Kimi K2.5 Turbo · FirePass subscription model',
+      descriptionForModel:
+        'Kimi K2.5 Turbo - FirePass subscription with 256K context, no per-token charges',
+    }
+  }
   return {
     value: 'haiku',
     label: 'Haiku',
@@ -253,6 +314,16 @@ function getHaiku35Option(): ModelOption {
       description: 'GPT-5.4 Mini for simple tasks',
       descriptionForModel:
         'GPT-5.4 Mini - lower latency OpenAI model for simple tasks',
+    }
+  }
+  if (provider === 'firepass') {
+    const firepassModel = getModelStrings().haiku35
+    return {
+      value: firepassModel,
+      label: 'Kimi K2.5 Turbo',
+      description: 'Kimi K2.5 Turbo · FirePass subscription model',
+      descriptionForModel:
+        'Kimi K2.5 Turbo - FirePass subscription with 256K context, no per-token charges',
     }
   }
   return {
@@ -403,6 +474,19 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     }
     payg1POptions.push(getHaiku45Option())
     return payg1POptions
+  }
+
+  // FirePass: Simple list with just Kimi K2.5 Turbo
+  if (getAPIProvider() === 'firepass') {
+    const firepassModel = getModelStrings().sonnet46
+    return [
+      getDefaultOptionForUser(fastMode),
+      {
+        value: firepassModel,
+        label: 'Kimi K2.5 Turbo',
+        description: 'Kimi K2.5 Turbo · 256K context, subscription billing',
+      },
+    ]
   }
 
   // PAYG 3P: Default (Sonnet 4.5) + Sonnet (3P custom) or Sonnet 4.6/1M + Opus (3P custom) or Opus 4.1/Opus 4.6/Opus1M + Haiku + Opus 4.1

--- a/src/utils/model/modelStrings.ts
+++ b/src/utils/model/modelStrings.ts
@@ -35,7 +35,20 @@ function getBuiltinModelStrings(provider: APIProvider): ModelStrings {
     const out = getBuiltinModelStrings('firstParty') as Record<string, string>
     out.sonnet46 =
       process.env.OPENROUTER_SONNET_MODEL || 'anthropic/claude-sonnet-4.6'
+    out.opus46 =
       process.env.OPENROUTER_OPUS_MODEL || 'anthropic/claude-opus-4.6'
+    return out as ModelStrings
+  }
+
+  if (provider === 'firepass') {
+    // FirePass uses Fireworks AI's Kimi K2.5 Turbo by default
+    // Users can override with FIREPASS_MODEL env var
+    const out = getBuiltinModelStrings('firstParty') as Record<string, string>
+    const firepassModel =
+      process.env.FIREPASS_MODEL || 'accounts/fireworks/routers/kimi-k2p5-turbo'
+    out.haiku45 = firepassModel
+    out.sonnet46 = firepassModel
+    out.opus46 = firepassModel
     return out as ModelStrings
   }
 

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -5,6 +5,7 @@ export type APIProvider =
   | 'firstParty'
   | 'openrouter'
   | 'openai'
+  | 'firepass'
   | 'bedrock'
   | 'vertex'
   | 'foundry'
@@ -20,10 +21,11 @@ function getStoredProviderPreference(): APIProvider | null {
       require('../env.js') as typeof import('../env.js')
     const raw = readFileSync(getGlobalClaudeFile(), 'utf8')
     const config = JSON.parse(raw) as {
-      authProvider?: 'anthropic' | 'openrouter' | 'openai'
+      authProvider?: 'anthropic' | 'openrouter' | 'openai' | 'firepass'
       openRouterApiKey?: string
       openAiApiKey?: string
       openAiAccessToken?: string
+      firepassApiKey?: string
     }
 
     switch (config.authProvider) {
@@ -33,6 +35,8 @@ function getStoredProviderPreference(): APIProvider | null {
         return config.openAiApiKey || config.openAiAccessToken
           ? 'openai'
           : null
+      case 'firepass':
+        return config.firepassApiKey ? 'firepass' : null
       case 'anthropic':
         return 'firstParty'
       default:
@@ -57,6 +61,10 @@ function getExplicitProviderOverride(): APIProvider | null {
       return 'openrouter'
     case 'openai':
       return 'openai'
+    case 'firepass':
+    case 'fire-pass':
+    case 'fire_pass':
+      return 'firepass'
     case 'bedrock':
       return 'bedrock'
     case 'vertex':
@@ -98,6 +106,28 @@ export function isOpenAIConfigured(): boolean {
   )
 }
 
+export function isFirepassBaseUrl(baseUrl?: string | null): boolean {
+  if (!baseUrl) {
+    return false
+  }
+  try {
+    const host = new URL(baseUrl).host
+    return host === 'api.fireworks.ai'
+  } catch {
+    return false
+  }
+}
+
+export function isFirepassConfigured(): boolean {
+  return (
+    getExplicitProviderOverride() === 'firepass' ||
+    Boolean(process.env.FIREPASS_API_KEY) ||
+    Boolean(process.env.FIREWORKS_API_KEY) ||
+    isFirepassBaseUrl(process.env.FIREPASS_BASE_URL) ||
+    isFirepassBaseUrl(process.env.ANTHROPIC_BASE_URL)
+  )
+}
+
 export function getOpenRouterBaseUrl(): string {
   const configuredBaseUrl = process.env.OPENROUTER_BASE_URL
   const fallbackBaseUrl = 'https://openrouter.ai/api'
@@ -129,6 +159,35 @@ export function getOpenAIBaseUrl(): string {
   return process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1'
 }
 
+/**
+ * Get the FirePass base URL for Anthropic-compatible API.
+ * FirePass uses Fireworks AI's inference endpoint with Anthropic compatibility.
+ * Default: https://api.fireworks.ai/inference (Anthropic SDK appends /v1/messages)
+ */
+export function getFirepassBaseUrl(): string {
+  const configuredBaseUrl = process.env.FIREPASS_BASE_URL
+  if (!configuredBaseUrl) {
+    return 'https://api.fireworks.ai/inference'
+  }
+
+  try {
+    const url = new URL(configuredBaseUrl)
+
+    // Normalize path for Anthropic SDK compatibility
+    // SDK appends /v1/messages, so base should be /inference not /inference/v1
+    if (url.host === 'api.fireworks.ai') {
+      const normalizedPath = url.pathname.replace(/\/+$/, '')
+      if (normalizedPath === '/inference/v1' || normalizedPath === '/v1') {
+        url.pathname = '/inference'
+      }
+    }
+
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return configuredBaseUrl
+  }
+}
+
 export function getAPIProvider(): APIProvider {
   const explicitProvider = getExplicitProviderOverride()
   if (explicitProvider) {
@@ -143,9 +202,11 @@ export function getAPIProvider(): APIProvider {
         ? 'foundry'
         : isOpenAIConfigured()
           ? 'openai'
-          : isOpenRouterConfigured()
-            ? 'openrouter'
-            : getStoredProviderPreference() ?? 'firstParty'
+          : isFirepassConfigured()
+            ? 'firepass'
+            : isOpenRouterConfigured()
+              ? 'openrouter'
+              : getStoredProviderPreference() ?? 'firstParty'
 }
 
 export function getAPIProviderForStatsig(): AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS {

--- a/src/utils/status.tsx
+++ b/src/utils/status.tsx
@@ -13,6 +13,7 @@ import { getIdeClientName, type IDEExtensionInstallationStatus, isJetBrainsIde, 
 import { getClaudeAiUserDefaultModelDescription, modelDisplayString } from './model/model.js';
 import {
   getAPIProvider,
+  getFirepassBaseUrl,
   getOpenAIBaseUrl,
   getOpenRouterBaseUrl,
 } from './model/providers.js';
@@ -248,6 +249,7 @@ export function buildAPIProviderProperties(): Property[] {
     const providerLabel = {
       openrouter: 'OpenRouter',
       openai: 'OpenAI',
+      firepass: 'FirePass',
       bedrock: 'AWS Bedrock',
       vertex: 'Google Vertex AI',
       foundry: 'Microsoft Foundry'
@@ -274,6 +276,11 @@ export function buildAPIProviderProperties(): Property[] {
     properties.push({
       label: 'OpenAI base URL',
       value: getOpenAIBaseUrl()
+    });
+  } else if (apiProvider === 'firepass') {
+    properties.push({
+      label: 'FirePass base URL',
+      value: getFirepassBaseUrl()
     });
   } else if (apiProvider === 'bedrock') {
     const bedrockBaseUrl = process.env.BEDROCK_BASE_URL;


### PR DESCRIPTION
## Summary

Adds support for FirePass, a new provider option that uses Fireworks AI's Kimi K2.5 Turbo model with subscription billing ($7/week, 256K context window).

## Features

- **New Provider**: `firepass` alongside existing `anthropic`, `openai`, `openrouter` options
- **Anthropic API Compatible**: Uses Anthropic SDK with custom baseURL (`https://api.fireworks.ai/inference`)
- **Simplified Model Selection**: Model picker shows only "Kimi K2.5 Turbo" for FirePass users
- **Proper Display Names**: Status bar and model display show "Kimi K2.5 Turbo" instead of raw model ID

## Usage

1. Run `/login` and select "FirePass"
2. Enter your Fireworks API key (via `FIREPASS_API_KEY` or `FIREWORKS_API_KEY` env var, or through the login flow)
3. Model picker automatically shows Kimi K2.5 Turbo options

## Changes

| File | Change |
|------|--------|
| `src/utils/model/providers.ts` | Add `firepass` provider detection, `isFirepassBaseUrl()`, `isFirepassConfigured()`, `getFirepassBaseUrl()` |
| `src/utils/auth.ts` | Add `FirepassApiKeySource` type, `getFirepassApiKey()`, `saveFirepassApiKey()` |
| `src/utils/config.ts` | Add `firepassApiKey` and `firepass` auth provider to config type |
| `src/services/api/client.ts` | Add firepass client creation with custom baseURL |
| `src/utils/http.ts` | Add firepass auth headers (`x-api-key`) |
| `src/utils/model/modelStrings.ts` | Return Kimi K2.5 Turbo model ID for firepass provider |
| `src/utils/model/model.ts` | Add Kimi display name handling, fix default model for firepass |
| `src/utils/model/modelOptions.ts` | Simplified model picker for firepass (Kimi K2.5 Turbo only) |
| `src/utils/status.tsx` | Display FirePass in status bar with base URL |
| `src/commands/login/login.tsx` | Add FirePass option to provider selection menu |
| `src/components/FirepassLoginFlow.tsx` | New component for FirePass login flow |

## Test Plan

1. Build and link the CLI locally
2. Run `/login` and select "FirePass"
3. Enter a valid Fireworks API key
4. Verify status bar shows "FirePass · Kimi K2.5 Turbo"
5. Run `/model` and verify only Kimi K2.5 Turbo options appear
6. Send a test message and verify the model responds correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added FirePass as a new authentication provider with dedicated login flow
- Implemented FirePass API key authentication with validation, error handling, and secure input management
- Kimi K2.5 Turbo model integrated as the default for FirePass users
- Automatic FirePass configuration detection and environment variable support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->