### PR TITLE
fix: getMaxToolUseConcurrency ReferenceError and ripgrep ENOENT fallback (#8)

### DIFF
--- a/src/services/tools/toolOrchestration.ts
+++ b/src/services/tools/toolOrchestration.ts
@@ -4,10 +4,11 @@ import { findToolByName, type ToolUseContext } from '../../Tool.js'
 import type { AssistantMessage, Message } from '../../types/message.js'
 import { all } from '../../utils/generators.js'
 import { type MessageUpdateLazy, runToolUse } from './toolExecution.js'
-export {
+import {
   DEFAULT_MAX_TOOL_USE_CONCURRENCY,
   getMaxToolUseConcurrency,
 } from './toolConcurrency.js'
+export { DEFAULT_MAX_TOOL_USE_CONCURRENCY, getMaxToolUseConcurrency }
 
 export type MessageUpdate = {
   message?: Message

--- a/src/utils/ripgrep.ts
+++ b/src/utils/ripgrep.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess, ExecFileException } from 'child_process'
 import { execFile, spawn } from 'child_process'
+import { existsSync } from 'fs'
 import memoize from 'lodash-es/memoize.js'
 import { homedir } from 'os'
 import * as path from 'path'
@@ -60,6 +61,12 @@ const getRipgrepConfig = memoize((): RipgrepConfig => {
     process.platform === 'win32'
       ? path.resolve(rgRoot, `${process.arch}-win32`, 'rg.exe')
       : path.resolve(rgRoot, `${process.arch}-${process.platform}`, 'rg')
+
+  // Fall back to system rg when the vendor binary is absent (e.g. npm installs
+  // that don't ship the vendor/ directory alongside dist/cli.mjs).
+  if (!existsSync(command)) {
+    return { mode: 'system', command: 'rg', args: [] }
+  }
 
   return { mode: 'builtin', command, args: [] }
 })


### PR DESCRIPTION
## Root causes

### Bug 1 — `getMaxToolUseConcurrency is not defined` (ReferenceError)

**File:** `src/services/tools/toolOrchestration.ts`

`runToolsConcurrently()` calls `getMaxToolUseConcurrency()` directly, but the function was only *re-exported* via:

```ts
export { DEFAULT_MAX_TOOL_USE_CONCURRENCY, getMaxToolUseConcurrency } from './toolConcurrency.js'
```

A re-export (`export { x } from './y'`) does **not** bring `x` into the current module's local scope — it only makes `x` available to importers of this module. Calling `getMaxToolUseConcurrency()` in the same file therefore throws `ReferenceError: getMaxToolUseConcurrency is not defined` at runtime. TypeScript also flagged this as `TS2304: Cannot find name 'getMaxToolUseConcurrency'` on `main`.

**Fix:** Replace the re-export with an explicit `import` (bringing the name into local scope) and a separate `export` statement:

```ts
import { DEFAULT_MAX_TOOL_USE_CONCURRENCY, getMaxToolUseConcurrency } from './toolConcurrency.js'
export { DEFAULT_MAX_TOOL_USE_CONCURRENCY, getMaxToolUseConcurrency }
```

### Bug 2 — `spawn .../vendor/ripgrep/x64-linux/rg ENOENT`

**File:** `src/utils/ripgrep.ts`

When `better-clawd` is installed via npm, only `dist/cli.mjs` is shipped (per the `files` field in `package.json`) — the `vendor/` directory containing the pre-built `rg` binary is not included. On a Node.js (non-Bun-compiled) runtime, `getRipgrepConfig()` falls through to the vendor path and tries to spawn a binary that doesn't exist.

**Fix:** Check whether the resolved vendor binary exists with `existsSync` before returning the `builtin` config; if absent, fall back to `{ mode: 'system', command: 'rg', args: [] }` (system ripgrep). Users who already have `rg` installed (as the issue reporter confirmed with `which rg`) get seamless fallback with no manual symlink required.

## Test plan

- [x] `bun test` — all 8 tests pass (0 fail)
- [x] `TS2304: Cannot find name 'getMaxToolUseConcurrency'` error on `main` is resolved by the import fix
- [x] No new TypeScript errors introduced (pre-existing errors unchanged)
- [x] No conflicts with upstream `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback handling for the ripgrep executable to gracefully switch to the system version if the built-in version is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->