### PR TITLE
Fix Enter key doing nothing on Apple Terminal (#6)

### DIFF
--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -259,7 +259,8 @@ export function useTextInput({
       return cursor.insert('\n')
     }
     // Apple Terminal doesn't support custom Shift+Enter keybindings,
-    // so we use native macOS modifier detection to check if Shift is held
+    // so we use native macOS modifier detection to check if Shift is held.
+    // isModifierPressed fails safe (returns false) if detection is unavailable.
     if (env.terminal === 'Apple_Terminal' && isModifierPressed('shift')) {
       return cursor.insert('\n')
     }

--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -244,6 +244,11 @@ export function useTextInput({
     ['y', handleYankPop],
   ])
 
+  /**
+   * Handle the Return key. Inserts a newline when the user requested one
+   * (backslash+Return, Meta/Shift+Return, or a Shift held on Apple Terminal,
+   * detected natively); otherwise submits the current value via onSubmit.
+   */
   function handleEnter(key: Key) {
     if (
       multiline &&

--- a/src/utils/modifiers.ts
+++ b/src/utils/modifiers.ts
@@ -28,9 +28,22 @@ export function isModifierPressed(modifier: ModifierKey): boolean {
   if (process.platform !== 'darwin') {
     return false
   }
-  // Dynamic import to avoid loading native module at top level
-  const { isModifierPressed: nativeIsModifierPressed } =
+  // Fail safe: if the native module is missing, stubbed, or throws, treat the
+  // modifier as not pressed. This function is called from the Enter handler on
+  // every keystroke — an uncaught throw here kills Enter entirely (the build
+  // stubs `modifiers-napi` with only a default export, so the named import
+  // below is undefined and calling it throws "is not a function").
+  try {
+    // Dynamic import to avoid loading native module at top level
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('modifiers-napi') as { isModifierPressed: (m: string) => boolean }
-  return nativeIsModifierPressed(modifier)
+    const native = require('modifiers-napi') as {
+      isModifierPressed?: (m: string) => boolean
+    }
+    if (typeof native?.isModifierPressed !== 'function') {
+      return false
+    }
+    return native.isModifierPressed(modifier) === true
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #6. On **Apple Terminal**, pressing Enter never submitted the prompt — characters typed fine, but Return was silently dead. This affects every Apple Terminal user, not an edge case.

## Root cause

`handleEnter()` in `useTextInput.ts` calls `isModifierPressed('shift')` on every Return, to support Shift+Enter newlines via native macOS modifier detection on Apple Terminal (which can't do custom Shift+Enter keybindings).

`isModifierPressed()` in `src/utils/modifiers.ts` destructures a **named** export from the native `modifiers-napi` module:

```ts
const { isModifierPressed: nativeIsModifierPressed } = require('modifiers-napi')
return nativeIsModifierPressed(modifier)
```

But `scripts/build.ts` stubs `modifiers-napi` (and the other native modules) with a stub that only exposes a `default` Proxy export — there is no named `isModifierPressed`. So `nativeIsModifierPressed` resolves to `undefined`, and calling it throws:

```
TypeError: nativeIsModifierPressed is not a function
```

The throw happens **inside `handleEnter()`, before `onSubmit()` is reached**. Ink swallows the error, so the user sees nothing — Enter just does nothing.

I confirmed this at runtime by logging the `handleEnter` path:

```
[handleEnter] term=Apple_Terminal onSubmitDefined=true value="hello"
[handleEnter] nativeShift="THREW: nativeIsModifierPressed is not a function"
```

Because `env.terminal === 'Apple_Terminal'` is the gate, only Apple Terminal users hit it; other terminals take a different newline path and never call into the native module on Enter.

## Fix

Make `isModifierPressed()` fail safe. A "is this modifier currently held?" probe must never be able to throw and take down the Enter key. If the native module is missing, stubbed, or throws, return `false` ("not pressed") so `handleEnter()` falls through to `onSubmit()`.

```ts
try {
  const native = require('modifiers-napi') as { isModifierPressed?: (m: string) => boolean }
  if (typeof native?.isModifierPressed !== 'function') return false
  return native.isModifierPressed(modifier) === true
} catch {
  return false
}
```

This also guards the same class of failure for the other `isModifierPressed` call sites.

## Testing

- Apple Terminal (macOS, the broken case): rebuilt with `bun run build`, Enter now submits prompts correctly.
- Behavior on terminals with working native detection is unchanged (the native function is still called when it exists).

The comment tweak in `useTextInput.ts` just notes that `isModifierPressed` now fails safe; no logic change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made modifier-key detection more robust by adding defensive error handling and safe fallbacks when native support is missing, preventing crashes and ensuring consistent behavior.

* **Documentation**
  * Clarified comment explaining when Return inserts a newline versus submits and noted safe fallback behavior for modifier detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->